### PR TITLE
feat: fix issued ticket generation and ticket fetcher flow

### DIFF
--- a/backend/src/main/java/io/ggroup/demo/controller/InspectController.java
+++ b/backend/src/main/java/io/ggroup/demo/controller/InspectController.java
@@ -22,6 +22,20 @@ public class InspectController {
         this.issuedTicketRepository = issuedTicketRepository;
     }
 
+    @Operation(summary = "Get ticket by QR code", description = "Returns issued ticket info by QR code")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Ticket found"),
+        @ApiResponse(responseCode = "404", description = "Ticket not found")
+    })
+    @GetMapping("/{qrCode}")
+    public ResponseEntity<?> getTicketByQrCode(@PathVariable String qrCode) {
+        return issuedTicketRepository.findByQrCode(qrCode)
+                .map(ticket -> ResponseEntity.ok((Object) ticket))
+                .orElseGet(() -> ResponseEntity
+                        .status(HttpStatus.NOT_FOUND)
+                        .body(new ErrorResponse(404, "Issued ticket not found with QR code")));
+    }
+
     @Operation(summary = "Mark ticket as used", description = "Marks a ticket as used by its QR code")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Ticket marked as used"),

--- a/backend/src/main/java/io/ggroup/demo/controller/OrderDetailsController.java
+++ b/backend/src/main/java/io/ggroup/demo/controller/OrderDetailsController.java
@@ -9,10 +9,12 @@ import org.springframework.web.bind.annotation.*;
 import io.ggroup.demo.model.*;
 import io.ggroup.demo.dto.*;
 
+import io.ggroup.demo.repository.IssuedTicketRepository;
 import io.ggroup.demo.repository.OrderDetailsRepository;
 import io.ggroup.demo.repository.OrderRepository;
 import io.ggroup.demo.repository.SellerRepository;
 import io.ggroup.demo.repository.TicketRepository;
+import io.ggroup.demo.service.QRService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,12 +34,14 @@ private final OrderDetailsRepository orderDetailsRepository;
 private final TicketRepository ticketRepository;
 private final OrderRepository orderRepository;
 private final SellerRepository sellerRepository;
+private final IssuedTicketRepository issuedTicketRepository;
 
-    public OrderDetailsController(OrderDetailsRepository orderDetailsRepository, TicketRepository ticketRepository, OrderRepository orderRepository, SellerRepository sellerRepository) {
+    public OrderDetailsController(OrderDetailsRepository orderDetailsRepository, TicketRepository ticketRepository, OrderRepository orderRepository, SellerRepository sellerRepository, IssuedTicketRepository issuedTicketRepository) {
         this.orderDetailsRepository = orderDetailsRepository;
         this.ticketRepository = ticketRepository;
         this.orderRepository = orderRepository;
         this.sellerRepository = sellerRepository;
+        this.issuedTicketRepository = issuedTicketRepository;
     }
 
     // GET /api/orderdetails - Get all order details
@@ -163,6 +167,13 @@ private final SellerRepository sellerRepository;
         ticketRepository.save(ticket);
 
         OrderDetails saved = orderDetailsRepository.save(orderDetails);
+
+        // Generate one IssuedTicket (with unique QR code) per ticket unit
+        for (int i = 0; i < request.getQuantity(); i++) {
+            IssuedTicket issuedTicket = new IssuedTicket(order, QRService.generate(), ticket);
+            issuedTicketRepository.save(issuedTicket);
+        }
+
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
     }
 

--- a/frontend/src/pages/admin/TicketFetcherPage.tsx
+++ b/frontend/src/pages/admin/TicketFetcherPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import externalClient from '../../api/externalClient';
+import apiClient from '../../api/apiClient';
 
 const TicketFetcherPage = () => {
   const [ticketId, setTicketId] = useState('');
@@ -14,7 +14,7 @@ const TicketFetcherPage = () => {
     setError(null);
     setResult(null);
     try {
-      const data = await externalClient.get<Record<string, unknown>>(`/api/inspect/${ticketId.trim()}`);
+      const data = await apiClient.get<Record<string, unknown>>(`/api/inspect/${ticketId.trim()}`);
       setResult(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');
@@ -28,7 +28,7 @@ const TicketFetcherPage = () => {
     setMarking(true);
     setError(null);
     try {
-      const data = await externalClient.put<Record<string, unknown>>(`/api/inspect/${ticketId.trim()}/use`);
+      const data = await apiClient.put<Record<string, unknown>>(`/api/inspect/${ticketId.trim()}/use`);
       setResult(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');


### PR DESCRIPTION
Huom tämä tehty feat/frontend-fixes haarasta joten base on nyt se jotta näkyy vain tämän haaran muutokset eli kun se on ensin mergetty deviin niin sen jälkeen tämän voi mergetä deviin.

## Summary

- `OrderDetailsController` auto-generates `IssuedTicket` records (one per unit) with a unique QR code when an order detail is created — previously tickets were purchased but no QR codes were ever generated
- `InspectController` gets a new `GET /api/inspect/{qrCode}` endpoint so the ticket fetcher can look up a ticket before marking it as used
- `TicketFetcherPage` was calling the Render production server via `externalClient` — switched to `apiClient` so it uses the local backend

## Test plan

- [ ] Purchase tickets via checkout flow
- [ ] Verify `GET /api/issuedtickets` returns issued tickets with QR codes
- [ ] Enter a QR code in Ticket Fetcher manual entry — verify ticket info appears
- [ ] Click "Mark as Used" — verify ticket is marked used
- [ ] Enter the same QR code again — verify 409 conflict response