### PR TITLE
fix: admin dashboard event statuses and seller role

### DIFF
--- a/backend/src/main/java/io/ggroup/demo/config/TestLoginConfig.java
+++ b/backend/src/main/java/io/ggroup/demo/config/TestLoginConfig.java
@@ -1,6 +1,8 @@
 package io.ggroup.demo.config;
 
+import io.ggroup.demo.model.Seller;
 import io.ggroup.demo.model.User;
+import io.ggroup.demo.repository.SellerRepository;
 import io.ggroup.demo.repository.UserRepository;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
@@ -14,28 +16,30 @@ public class TestLoginConfig {
     //customer@test salasana customer123
     @Bean
     public CommandLineRunner createTestUsers(
-            UserRepository userRepo, 
+            UserRepository userRepo,
+            SellerRepository sellerRepo,
             PasswordEncoder encoder) {
             return args -> {
 
             if (userRepo.findByEmail("admin@test.com").isEmpty()) {
-                // Create new admin user
                 User admin = new User();
                 admin.setEmail("admin@test.com");
                 admin.setPasswordHash(encoder.encode("admin123"));
-
                 userRepo.save(admin);
-
                 System.out.println("Admin user created: admin@test.com / admin123");
             }
 
             if (userRepo.findByEmail("seller@test.com").isEmpty()) {
-                // Create new seller user
-                User seller = new User();
-                seller.setEmail("seller@test.com");
-                seller.setPasswordHash(encoder.encode("seller123"));
+                User sellerUser = new User();
+                sellerUser.setEmail("seller@test.com");
+                sellerUser.setPasswordHash(encoder.encode("seller123"));
+                userRepo.save(sellerUser);
 
-                userRepo.save(seller);
+                Seller seller = new Seller();
+                seller.setEmail("seller@test.com");
+                seller.setName("Test Seller");
+                seller.setUser(sellerUser);
+                sellerRepo.save(seller);
 
                 System.out.println("Seller user created: seller@test.com / seller123");
             }

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,9 +1,11 @@
 import { createContext, useContext, useState, ReactNode } from 'react';
 import apiClient from '../api/apiClient';
 
+type UserRole = 'admin' | 'seller' | 'customer' | 'user';
+
 interface AuthUser {
   email: string;
-  role: string;
+  role: UserRole;
 }
 
 interface AuthContextType {
@@ -21,7 +23,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   });
 
   const login = async (email: string, password: string) => {
-    const response = await apiClient.post<{ email: string; role: string }>('/api/auth/login', {
+    const response = await apiClient.post<{ email: string; role: UserRole }>('/api/auth/login', {
       email,
       password,
     });

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -9,7 +9,8 @@ const HomePage = () => {
   const [searchParams] = useSearchParams();
   const [events, setEvents] = useState<Event[]>([]);
   const q = (searchParams.get('q') ?? '').toLowerCase();
-  const filteredEvents = q ? events.filter((e) => e.title.toLowerCase().includes(q)) : events;
+  const upcomingEvents = events.filter((e) => e.eventStatus.eventStatus === 'upcoming');
+  const filteredEvents = q ? upcomingEvents.filter((e) => e.title.toLowerCase().includes(q)) : upcomingEvents;
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -3,6 +3,18 @@ import { Link, useNavigate } from 'react-router-dom';
 import { getEvents } from '../../api/eventService';
 import { Event, formatEventDate } from '../../types/event';
 
+const STATUS_GROUPS = [
+  { key: 'upcoming', label: 'Upcoming Events' },
+  { key: 'cancelled', label: 'Cancelled Events' },
+  { key: 'finished', label: 'Finished Events' },
+];
+
+const STATUS_STYLES: Record<string, string> = {
+  upcoming: 'bg-primary/10 text-primary',
+  cancelled: 'bg-error/10 text-error',
+  finished: 'bg-surface-container-high text-on-surface-variant',
+};
+
 const DashboardPage = () => {
   const navigate = useNavigate();
   const [events, setEvents] = useState<Event[]>([]);
@@ -15,10 +27,12 @@ const DashboardPage = () => {
       .finally(() => setLoading(false));
   }, []);
 
-  const upcomingEvents = events
-    .filter((e) => e.eventStatus.eventStatus === 'upcoming')
-    .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
-    .slice(0, 5);
+  const upcomingEvents = events.filter((e) => e.eventStatus.eventStatus === 'upcoming');
+
+  const groupedEvents = (status: string) =>
+    events
+      .filter((e) => e.eventStatus.eventStatus === status)
+      .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
 
   const stats = [
     {
@@ -79,39 +93,43 @@ const DashboardPage = () => {
           ))}
         </div>
 
-        {/* Upcoming Events */}
-        <section className="space-y-4">
-          <div className="flex items-baseline gap-4">
-            <h2 className="text-base font-bold text-on-surface">Upcoming Events</h2>
-            <span className="h-px flex-1 bg-surface-container-high" />
-            <Link to="/admin/events/create" className="text-xs font-semibold text-primary hover:underline">
-              + New event
-            </Link>
-          </div>
-          <div className="bg-surface-container-lowest border border-outline-variant/10 rounded-xl divide-y divide-surface-container-low overflow-hidden">
-            {upcomingEvents.length === 0 ? (
-              <p className="text-sm text-on-surface-variant text-center py-10">No upcoming events.</p>
-            ) : (
-              upcomingEvents.map((event) => (
-                <div
-                  key={event.eventId}
-                  onClick={() => navigate(`/admin/events/${event.eventId}/edit`)}
-                  className="flex items-center justify-between px-5 py-4 hover:bg-surface-container-low transition-colors cursor-pointer"
-                >
-                  <div className="min-w-0">
-                    <p className="text-sm font-semibold text-on-surface truncate">{event.title}</p>
-                    <p className="text-xs text-on-surface-variant mt-0.5">
-                      {formatEventDate(event.startTime)} · {event.venue.name}, {event.venue.postalCode.city}
-                    </p>
-                  </div>
-                  <span className="ml-4 shrink-0 text-[10px] font-bold px-2 py-1 rounded-full bg-secondary-container text-on-secondary-container uppercase tracking-wide">
-                    {event.category.category}
-                  </span>
-                </div>
-              ))
-            )}
-          </div>
-        </section>
+        {/* Events grouped by status */}
+        {STATUS_GROUPS.map(({ key, label }) => {
+          const group = groupedEvents(key);
+          if (group.length === 0) return null;
+          return (
+            <section key={key} className="space-y-4">
+              <div className="flex items-baseline gap-4">
+                <h2 className="text-base font-bold text-on-surface">{label}</h2>
+                <span className="h-px flex-1 bg-surface-container-high" />
+                {key === 'upcoming' && (
+                  <Link to="/admin/events/create" className="text-xs font-semibold text-primary hover:underline">
+                    + New event
+                  </Link>
+                )}
+              </div>
+              <div className="bg-surface-container-lowest border border-outline-variant/10 rounded-xl divide-y divide-surface-container-low overflow-hidden">
+                {group.map((event) => (
+                    <div
+                      key={event.eventId}
+                      onClick={() => navigate(`/admin/events/${event.eventId}/edit`)}
+                      className="flex items-center justify-between px-5 py-4 hover:bg-surface-container-low transition-colors cursor-pointer"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-on-surface truncate">{event.title}</p>
+                        <p className="text-xs text-on-surface-variant mt-0.5">
+                          {formatEventDate(event.startTime)} · {event.venue.name}, {event.venue.postalCode.city}
+                        </p>
+                      </div>
+                      <span className={`ml-4 shrink-0 text-[10px] font-bold px-2 py-1 rounded-full uppercase tracking-wide ${STATUS_STYLES[key]}`}>
+                        {key}
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            </section>
+          );
+        })}
 
       </div>
     </>


### PR DESCRIPTION
## Summary
- Dashboard groups events by status (Upcoming / Cancelled / Finished), empty sections hidden
- Homepage shows only upcoming events
- Fixed `seller@test.com` not being added to Sellers table, causing wrong role (`user` instead of `seller`) and missing Admin button
- Typed `AuthUser.role` as `'admin' | 'seller' | 'customer' | 'user'` union instead of `string`